### PR TITLE
Make docker-entrypoint effectively support bitcoind from another container

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -8,17 +8,30 @@ export BTC_PATH=/data/bitcoin
 : ${NETWORK:=testnet}
 : ${LIGHTNINGD_OPT:=--log-level=debug}
 : ${BITCOIND_OPT:=-debug=rpc}
+: ${BITCOIND_HOST:=127.0.0.1}
 
 [[ "$NETWORK" == "mainnet" ]] && NETWORK=bitcoin
 
-mkdir -p $BTC_PATH $LN_PATH
+mkdir -p $LN_PATH
 
 if [ -z "$SKIP_BITCOIND" ]; then
+  mkdir -p $BTC_PATH
   echo "Starting bitcoind"
   bitcoind -printtoconsole -$NETWORK -datadir=$BTC_PATH $BITCOIND_OPTS &>> /data/bitcoin.log &
-  echo "Waiting for bitcoind to startup"
-  sed '/init message: Done loading/ q' <(tail -F -n0 /data/bitcoin.log 2> /dev/null)
+  # We need to wait at least until the cookiefile is created...
+  sleep 1
+else
+  # The path should be out of /data, because /data is the volume concerning this container only
+  BTC_PATH=/root/.bitcoin
+  echo "Using external bitcoind '$BITCOIND_HOST'"
+  # LightningD depends on bitcoin-cli which use the rpcconnect argument to know the host to connect to.
+  # We can't configure LightningD to use a different host, but we can configure the underlying bitcoin-cli to use it
+  sed -i '/^rpcconnect=/d' $BTC_PATH/bitcoin.conf
+  echo "rpcconnect=$BITCOIND_HOST" >> $BTC_PATH/bitcoin.conf
 fi
+
+echo "Waiting for bitcoind to startup"
+bitcoin-cli -$NETWORK -datadir="$BTC_PATH" -rpcwait getblockchaininfo  &>> /dev/null
 
 if [ -z "$SKIP_LIGHTNINGD" ]; then
   echo "Starting lightningd"


### PR DESCRIPTION
With the way it was done before, using the image with another bitcoind would not work because lightningd was still trying to use 127.0.0.1 for bitcoin RPC.

The trick is to add `rpcconnect` in the configuration file in the bitcoind folder. This make bitcoin-cli use a different host than 127.0.0.1 by default.

I also changed the way to wait for bitcoin core to start by using `bitcoin-cli -rpcwait` instead of looking for a file in debug logs. (As if bitcoind is in another container, we don't have access to the logs)