### PR TITLE
Smaller docker image by using two stage build and less layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,53 @@
-FROM ubuntu:16.04
+FROM node:8.9-slim as builder
 
-ENV LIGHTNINGD_VERSION=master
-ENV BITCOIN_PPA_KEY=C70EF1F0305A1ADB9986DBD8D46F45428842CE5E
-ENV HOME=/tmp
-
-RUN apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates jq inotify-tools
-RUN mkdir /data
-
-# bitcoind
-RUN gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $BITCOIN_PPA_KEY && \
-    gpg --export --armor $BITCOIN_PPA_KEY | apt-key add - && \
-    echo deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main | tee /etc/apt/sources.list.d/bitcoin.list && \
-    apt-get update -o Dir::Etc::sourcelist=sources.list.d/bitcoin.list -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0 && \
-    apt-get install -y bitcoind
+RUN apt-get update && apt-get install -y --no-install-recommends git curl build-essential ca-certificates jq inotify-tools wget \
+    autoconf automake build-essential libtool libgmp-dev libsqlite3-dev python python3
 
 # lightningd
-RUN apt-get install -y --no-install-recommends autoconf automake build-essential libtool libgmp-dev libsqlite3-dev python python3 && \
-    git clone https://github.com/ElementsProject/lightning.git /opt/lightningd && \
+ENV LIGHTNINGD_VERSION=master
+RUN git clone https://github.com/ElementsProject/lightning.git /opt/lightningd && \
     cd /opt/lightningd && \
     git checkout $LIGHTNINGD_VERSION && \
-    make && cp lightningd/lightning* cli/lightning-cli /usr/bin/
+    make && rm -rf *.c *.h *.o Makefile test
 
-# nodejs 8
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo deb http://deb.nodesource.com/node_8.x xenial main | tee /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update -o Dir::Etc::sourcelist=sources.list.d/nodesource.list -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0 && \
-    apt-get install -y nodejs
+# bitcoind
+ENV BITCOIN_VERSION 0.15.1
+ENV BITCOIN_URL https://bitcoincore.org/bin/bitcoin-core-0.15.1/bitcoin-0.15.1-x86_64-linux-gnu.tar.gz
+ENV BITCOIN_SHA256 387c2e12c67250892b0814f26a5a38f837ca8ab68c86af517f975a2a2710225b
+ENV BITCOIN_ASC_URL https://bitcoincore.org/bin/bitcoin-core-0.15.1/SHA256SUMS.asc
+ENV BITCOIN_PGP_KEY 01EA5486DE18A882D4C2684590C8019E36C2E964
+RUN mkdir -p /tmp/bitcoin \
+    && cd /tmp/bitcoin \
+	&& wget -qO bitcoin.tar.gz "$BITCOIN_URL" \
+	&& echo "$BITCOIN_SHA256 bitcoin.tar.gz" | sha256sum -c - \
+	&& gpg --keyserver keyserver.ubuntu.com --recv-keys "$BITCOIN_PGP_KEY" \
+	&& wget -qO bitcoin.asc "$BITCOIN_ASC_URL" \
+	&& gpg --verify bitcoin.asc \
+	&& tar -xzvf bitcoin.tar.gz -C /tmp/bitcoin --strip-components=1 --exclude=*-qt \
+    && mkdir -p /opt/bitcoin \
+    && cp /tmp/bitcoin/bin/bitcoind /opt/bitcoin/bitcoind \
+    && cp /tmp/bitcoin/bin/bitcoin-cli /opt/bitcoin/bitcoin-cli \
+	&& rm -rf /tmp/bitcoin
 
-# Lightning Charge
 WORKDIR /opt/charged
 COPY package*.json ./
 RUN npm install
+
+FROM node:8.9-slim
+
+COPY --from=builder /opt/lightningd/lightningd /usr/bin
+COPY --from=builder /opt/lightningd/cli/lightning-cli /usr/bin/lightning-cli
+COPY --from=builder /opt/bitcoin/bitcoind /usr/bin/bitcoind
+COPY --from=builder /opt/bitcoin/bitcoin-cli /usr/bin/bitcoin-cli
+COPY --from=builder /opt/charged /opt/charged
+
+WORKDIR /opt/charged
+ENV HOME=/tmp
+RUN mkdir -p /data
+
+RUN apt-get update && apt-get install -y --no-install-recommends libgmp-dev libsqlite3-dev jq inotify-tools && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY . .
 RUN ln -s /opt/charged/bin/charged /usr/bin/charged
 CMD bin/docker-entrypoint.sh


### PR DESCRIPTION
I first tried to use alpine image instead of ubuntu. It turns out a dependencies on glibc from clightning prevented me to do that.

Nevertheless, I could drastically lower the size of the image by using a two stage build (-200MB) and making less layers. (-200MB)

Note that if `package.json` change, the cache is invalidated and nodejs need to be downloaded again.
This was not the case before but by installing, then uninstalling tools needed by `npm install` in the same layer, I could gain an additional 200MB.

`package.json` is rarely changing so it is not such a big deal.

The image size decreased from 692MB to 223MB. (around 67% smaller)

I am also downloading bitcoin core from bitcoin core website and check hashes + signatures instead of relying on the ppa.

If lightning can get rid of glibc dependency, then the size would be decreased by an additional 100MB.