### PR TITLE
Properly make charged as PID1 if standalone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ WORKDIR /opt/charged
 ARG TESTRUNNER
 ENV HOME /tmp
 ENV NODE_ENV production
+ARG STANDALONE
+ENV STANDALONE=$STANDALONE
 
 RUN ([ -n "$STANDALONE" ] || ( \
           apt-get update && apt-get install -y --no-install-recommends inotify-tools libgmp-dev libsqlite3-dev \
@@ -70,5 +72,5 @@ RUN ([ -n "$STANDALONE" ] || ( \
 COPY --from=builder /opt/bin /usr/bin
 COPY --from=builder /opt/charged /opt/charged
 
-CMD bin/docker-entrypoint.sh
+CMD [ "bin/docker-entrypoint.sh" ]
 EXPOSE 9112 9735


### PR DESCRIPTION
Fixing two issues:

1. The standalone build argument was not set as an environment variable during container runtime
2. CMD was using the `shell form` instead of the `exec form`. This mean that /bin/sh was running the entrypoint which invoked /bin/bash. So after the `exec`, PID 1 was in fact the /bin/sh process instead of charged.