### PR TITLE
README: add port lightningc RPC on docker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To deploy Lightning Charge with Docker, run these commands:
 
 ```bash
 $ mkdir data # make sure to create the folder _before_ running docker
-$ docker run -u `id -u` -v `pwd`/data:/data -p 9112:9112 \
+$ docker run -u `id -u` -v `pwd`/data:/data -p 9735:9735 -p 9112:9112 \
              -e API_TOKEN=mySecretToken \
              shesek/lightning-charge
 ```


### PR DESCRIPTION
Just a tiny change to improve the Readme:

For others to connect to our node, Lightningc's RPC needs to be exposed as well, (This is also marked in the Dockerfile as well)