### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Created
 
 ### `GET /payment-stream`
 
-Subscribe to payment updates as a [server-sent events](https://streamdata.io/blog/server-sent-events/) stream.
+Subscribe to payment updates as a [server-sent events](https://apifriends.com/api-streaming/server-sent-events/) stream.
 
 ```bash
 $ curl $CHARGE/payment-stream


### PR DESCRIPTION
Updated old link going to streamdata to apifriends which now hosts all old streamdata blogs