### PR TITLE
Allow creation of reusable lnurl-pay endpoints

### DIFF
--- a/migrations/20201101170804_lnurlpay.js
+++ b/migrations/20201101170804_lnurlpay.js
@@ -1,0 +1,26 @@
+exports.up = async db => {
+  await db.schema.createTable('lnurlpay_endpoint', t => {
+    t.string('id').primary()
+    t.string('metadata').notNullable().defaultTo('{}')
+    t.integer('min').notNullable()
+    t.integer('max').notNullable()
+    t.string('currency').nullable()
+    t.string('text').notNullable()
+    t.string('image').nullable()
+    t.string('success_text').nullable()
+    t.string('success_secret').nullable()
+    t.string('success_url').nullable()
+    t.integer('comment').notNullable().defaultTo(0)
+    t.string('webhook').nullable()
+  })
+  await db.schema.table('invoice', t => {
+    t.string('lnurlpay_endpoint').nullable()
+  })
+}
+
+exports.down = async db => {
+  await db.schema.dropTable('lnurlpay_endpoint')
+  await db.schema.table('invoice', t => {
+    t.dropColumn('lnurlpay_endpoint')
+  })
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.10.1",
     "basic-auth": "^2.0.1",
+    "bech32": "^1.1.4",
     "big.js": "^5.2.2",
     "body-parser": "^1.19.0",
     "clightning-client": "^0.1.2",

--- a/src/app.js
+++ b/src/app.js
@@ -37,6 +37,7 @@ const lnPath   = process.env.LN_PATH || join(require('os').homedir(), '.lightnin
 
   require('./invoicing')(app, payListen, model, auth, lnconf)
   require('./checkout')(app, payListen)
+  require('./lnurl')(app, payListen, model, auth)
 
   require('./sse')(app, payListen, auth)
   require('./webhook')(app, payListen, model, auth)

--- a/src/lnurl.js
+++ b/src/lnurl.js
@@ -1,0 +1,116 @@
+import bech32 from 'bech32'
+import wrap from './lib/promise-wrap'
+
+const debug = require('debug')('lightning-charge')
+
+module.exports = (app, payListen, model, auth) => {
+  const {
+    newInvoice, listInvoicesByLnurlPayEndpoint
+  , getLnurlPayEndpoint, listLnurlPayEndpoints
+  , setLnurlPayEndpoint, delLnurlPayEndpoint
+  } = model
+
+  app.get('/endpoints', auth, wrap(async (req, res) =>
+    res.status(200).send(
+      (await listLnurlPayEndpoints())
+        .map(lnurlpay => addBech23Lnurl(req, lnurlpay))
+    )))
+
+  app.post('/endpoint', auth, wrap(async (req, res) =>
+    res.status(201).send(
+      addBech23Lnurl(req, await setLnurlPayEndpoint(null, req.body))
+    )))
+
+  app.put('/endpoint/:id', auth, wrap(async (req, res) =>
+    res.status(200).send(
+      addBech23Lnurl(req, await setLnurlPayEndpoint(req.params.id, req.body))
+    )))
+
+  app.delete('/endpoint/:id', auth, wrap(async (req, res) =>
+    res.status(200).send(await delLnurlPayEndpoint(req.params.id))))
+
+  app.get('/endpoint/:id', auth, wrap(async (req, res) =>
+    res.status(200).send(
+      addBech23Lnurl(req, await getLnurlPayEndpoint(req.params.id))
+    )))
+
+  app.get('/endpoint/:id/invoices', auth, wrap(async (req, res) =>
+    res.send(await listInvoicesByLnurlPayEndpoint(req.params.id))))
+
+  // this is the actual endpoint users will hit
+  app.get('/lnurl/:id', wrap(async (req, res) => {
+    const lnurlpay = await getLnurlPayEndpoint(req.params.id)
+
+    res.status(200).send({
+      tag: 'payRequest'
+    , minSendable: lnurlpay.min
+    , maxSendable: lnurlpay.max
+    , metadata: makeMetadata(lnurlpay)
+    , commentAllowed: lnurlpay.comment
+    , callback: `https://${req.hostname}/lnurl/${lnurlpay.id}/callback`
+    })
+  }))
+
+  app.get('/lnurl/:id/callback', wrap(async (req, res) => {
+    const lnurlpay = await getLnurlPayEndpoint(req.params.id)
+
+    if (req.query.amount > lnurlpay.max)
+      return res.send({status: 'ERROR', reason: 'amount too large'})
+    if (req.query.amount < lnurlpay.min)
+      return res.send({status: 'ERROR', reason: 'amount too small'})
+
+    let invoiceMetadata = {...req.query}
+    delete invoiceMetadata.amount
+    delete invoiceMetadata.fromnodes
+    delete invoiceMetadata.nonce
+    invoiceMetadata = {...lnurlpay.metadata, ...invoiceMetadata}
+
+    const invoice = await newInvoice({
+      descriptionHash: require('crypto')
+        .createHash('sha256')
+        .update(makeMetadata(lnurlpay))
+        .digest('hex')
+    , msatoshi: req.query.amount
+    , metadata: invoiceMetadata
+    , webhook: lnurlpay.webhook
+    , lnurlpay_endpoint: lnurlpay.id
+    })
+
+    let successAction
+    if (lnurlpay.success_url) {
+      successAction = {
+        tag: 'url'
+      , url: lnurlpay.success_url
+      , description: lnurlpay.success_text || ''
+      }
+    } else if (lnurlpay.success_value) {
+      // not implemented yet
+    } else if (lnurlpay.success_text) {
+      successAction = {tag: 'message', message: lnurlpay.success_text}
+    }
+
+    res.status(200).send({
+      pr: invoice.payreq
+    , successAction
+    , routes: []
+    , disposable: false
+    })
+  }))
+}
+
+function makeMetadata (lnurlpay) {
+  const text = lnurlpay.text
+
+  const meta = [['text/plain', text]]
+    .concat(lnurlpay.image ? ['image/png;base64', lnurlpay.image] : [])
+
+  return JSON.stringify(meta)
+}
+
+function addBech23Lnurl (req, lnurlpay) {
+  const hostname = req.hostname || req.params.hostname
+  const url = `https://${hostname}/lnurl/${lnurlpay.id}`
+  const words = bech32.toWords(Buffer.from(url))
+  lnurlpay.bech32 = bech32.encode('lnurl', words, 2500).toUpperCase()
+  return lnurlpay
+}

--- a/src/model.js
+++ b/src/model.js
@@ -4,6 +4,7 @@ import { toMsat } from './lib/exchange-rate'
 const debug  = require('debug')('lightning-charge')
     , status = inv => inv.pay_index ? 'paid' : inv.expires_at > now() ? 'unpaid' : 'expired'
     , format = inv => ({ ...inv, status: status(inv), msatoshi: (inv.msatoshi || null), metadata: JSON.parse(inv.metadata) })
+    , formatLnurlpay = lnurlpay => ({...lnurlpay, metadata: JSON.parse(lnurlpay.metadata)})
     , now    = _ => Date.now() / 1000 | 0
 
 // @XXX invoices that accept any amount are stored as msatoshi='' (empty string)
@@ -16,12 +17,13 @@ const defaultDesc = process.env.INVOICE_DESC_DEFAULT || 'Lightning Charge Invoic
 
 module.exports = (db, ln) => {
   const newInvoice = async props => {
-    const { currency, amount, expiry, description, metadata, webhook } = props
+    const { currency, amount, expiry, metadata, webhook, lnurlpay_endpoint } = props
 
     const id       = nanoid()
         , msatoshi = props.msatoshi ? ''+props.msatoshi : currency ? await toMsat(currency, amount) : ''
-        , desc     = props.description ? ''+props.description : defaultDesc
-        , lninv    = await ln.invoice(msatoshi || 'any', id, desc, expiry)
+        , desc     = props.descriptionHash || (props.description ? ''+props.description : defaultDesc)
+        , method   = props.descriptionHash ? 'invoicewithdescriptionhash' : 'invoice'
+        , lninv    = await ln.call(method, [msatoshi || 'any', id, desc, expiry])
 
     const invoice = {
       id, msatoshi, description: desc
@@ -29,6 +31,7 @@ module.exports = (db, ln) => {
     , rhash: lninv.payment_hash, payreq: lninv.bolt11
     , expires_at: lninv.expires_at, created_at: now()
     , metadata: JSON.stringify(metadata || null)
+    , lnurlpay_endpoint
     }
 
     debug('saving invoice:', invoice)
@@ -48,6 +51,66 @@ module.exports = (db, ln) => {
   const delInvoice = async (id, status) => {
     await ln.delinvoice(id, status)
     await db('invoice').where({ id }).del()
+  }
+
+  const listLnurlPayEndpoints = _ =>
+    db('lnurlpay_endpoint')
+      .then(rows => rows.map(formatLnurlpay))
+
+  const listInvoicesByLnurlPayEndpoint = lnurlpayId =>
+    db('invoice')
+      .where({ lnurlpay_endpoint: lnurlpayId })
+      .then(rows => rows.map(format))
+
+  const getLnurlPayEndpoint = async id => {
+    let lnurlpay = await db('lnurlpay_endpoint').where({ id }).first()
+    return formatLnurlpay(lnurlpay)
+  }
+
+  const setLnurlPayEndpoint = async (id, props) => {
+    let lnurlpay
+    if (id) {
+      lnurlpay = await db('lnurlpay_endpoint').where({ id }).first()
+      lnurlpay = { ...lnurlpay, ...props }
+    } else
+      lnurlpay = { ...props, id: nanoid() }
+
+    if (typeof props.metadata != 'undefined') {
+      let metadata = JSON.stringify(props.metadata || {})
+      if (metadata[0] != '{')
+        metadata = '{}'
+
+      lnurlpay.metadata = metadata
+    }
+
+    if (props.amount) {
+      lnurlpay.min = props.amount
+      lnurlpay.max = props.amount
+    } else if (props.min <= props.max) {
+      lnurlpay.min = props.min
+      lnurlpay.max = props.max
+    } else if (props.min > props.max) {
+      // silently correct a user error
+      lnurlpay.min = props.max
+      lnurlpay.max = props.min
+    }
+
+    if (lnurlpay.min && !lnurlpay.max)
+      lnurlpay.max = lnurlpay.min
+
+    if (lnurlpay.max && !lnurlpay.min)
+      lnurlpay.min = lnurlpay.max
+
+    await db('lnurlpay_endpoint')
+      .insert(lnurlpay)
+      .onConflict('id')
+      .merge()
+
+    return formatLnurlpay(lnurlpay)
+  }
+
+  const delLnurlPayEndpoint = async id => {
+    await db('lnurlpay_endpoint').where({ id }).del()
   }
 
   const markPaid = (id, pay_index, paid_at, msatoshi_received) =>
@@ -85,7 +148,8 @@ module.exports = (db, ln) => {
            : { requested_at: now(), success: false, resp_error: err })
 
   return { newInvoice, listInvoices, fetchInvoice, delInvoice
+         , listInvoicesByLnurlPayEndpoint, listLnurlPayEndpoints
+         , getLnurlPayEndpoint, setLnurlPayEndpoint, delLnurlPayEndpoint
          , getLastPaid, markPaid, delExpired
          , addHook, getHooks, logHook }
 }
-


### PR DESCRIPTION
- [x] add a new table 'lnurlpay_endpoint' and a column to the 'invoice' table for loosely referecing the lnurl-pay endpoint an invoice is related to when applicable
- [x] add /endpoint* routes for creating and managing lnurl-pay endpoints
- [x] add /lnurl/:endpoint_id* routes callable by wallets that return invoices
- [x] `message` successAction
- [x] `url` successAction
- [ ] `aes` successAction
- [x] lnurl-pay comments
- [x] webhooks integration
- [x] metadata integration
- [ ] fiat currencies integration
- [ ] tests