### PR TITLE
Add User-Agent header to Coingecko request

### DIFF
--- a/src/lib/exchange-rate.js
+++ b/src/lib/exchange-rate.js
@@ -29,6 +29,7 @@ const getRateBitstamp = currency =>
 
 const getRateCoingecko = currency =>
   request.get(`https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=${enc(currency)}`)
+    .set('User-Agent','lightning-charge/0.4')
     .proxy(RATE_PROXY)
     .then(res => res.body.bitcoin[currency.toLowerCase()] || Promise.reject(`Unknown currency: ${currency}`))
 


### PR DESCRIPTION
requests to Coingecko are failing with 403 Forbidden: Please add a descriptive User-Agent to your request. For higher rate limits & stable integration, please subscribe to our API plans: https://www.coingecko.com/en/api/pricing . If you think this is a mistake, please report here: https://forms.gle/3V2z8Mb3k2RMu5S2A